### PR TITLE
Implement reservation CRUD with notifications

### DIFF
--- a/src/main/java/com/playtodoo/modulith/config/WebSocketConfig.java
+++ b/src/main/java/com/playtodoo/modulith/config/WebSocketConfig.java
@@ -1,0 +1,24 @@
+package com.playtodoo.modulith.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws").setAllowedOrigins("*");
+        registry.addEndpoint("/ws").setAllowedOrigins("*").withSockJS();
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic");
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+}

--- a/src/main/java/com/playtodoo/modulith/notifications/NotificationService.java
+++ b/src/main/java/com/playtodoo/modulith/notifications/NotificationService.java
@@ -1,0 +1,16 @@
+package com.playtodoo.modulith.notifications;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public void send(String message) {
+        messagingTemplate.convertAndSend("/topic/notifications", message);
+    }
+}

--- a/src/main/java/com/playtodoo/modulith/reservations/application/ReservationService.java
+++ b/src/main/java/com/playtodoo/modulith/reservations/application/ReservationService.java
@@ -1,0 +1,12 @@
+package com.playtodoo.modulith.reservations.application;
+
+import com.playtodoo.modulith.reservations.validation.CreateReservationDto;
+import com.playtodoo.modulith.reservations.validation.ReservationDto;
+
+import java.util.UUID;
+
+public interface ReservationService {
+    ReservationDto create(CreateReservationDto dto);
+    ReservationDto update(UUID id, CreateReservationDto dto);
+    ReservationDto cancel(UUID id);
+}

--- a/src/main/java/com/playtodoo/modulith/reservations/application/impl/ReservationServiceImpl.java
+++ b/src/main/java/com/playtodoo/modulith/reservations/application/impl/ReservationServiceImpl.java
@@ -1,0 +1,62 @@
+package com.playtodoo.modulith.reservations.application.impl;
+
+import com.playtodoo.modulith.notifications.NotificationService;
+import com.playtodoo.modulith.reservations.application.ReservationService;
+import com.playtodoo.modulith.reservations.domain.Reservation;
+import com.playtodoo.modulith.reservations.exception.ReservationNotFoundException;
+import com.playtodoo.modulith.reservations.infrastructure.ReservationRepository;
+import com.playtodoo.modulith.reservations.mapper.ReservationMapper;
+import com.playtodoo.modulith.reservations.validation.CreateReservationDto;
+import com.playtodoo.modulith.reservations.validation.ReservationDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ReservationServiceImpl implements ReservationService {
+
+    private final ReservationRepository repository;
+    private final ReservationMapper mapper;
+    private final NotificationService notificationService;
+
+    @Override
+    public ReservationDto create(CreateReservationDto dto) {
+        Reservation reservation = mapper.toReservation(dto);
+        Reservation saved = repository.save(reservation);
+        ReservationDto result = mapper.toReservationDto(saved);
+        notificationService.send("Reservation created " + saved.getId());
+        return result;
+    }
+
+    @Override
+    public ReservationDto update(UUID id, CreateReservationDto dto) {
+        Reservation reservation = repository.findById(id)
+                .orElseThrow(() -> new ReservationNotFoundException(id.toString()));
+        reservation.setCourtId(dto.courtId());
+        reservation.setUserId(dto.userId());
+        reservation.setStartTime(dto.startTime());
+        reservation.setEndTime(dto.endTime());
+        if (dto.status() != null) {
+            reservation.setStatus(dto.status());
+        }
+        Reservation updated = repository.save(reservation);
+        ReservationDto result = mapper.toReservationDto(updated);
+        notificationService.send("Reservation updated " + updated.getId());
+        return result;
+    }
+
+    @Override
+    public ReservationDto cancel(UUID id) {
+        Reservation reservation = repository.findById(id)
+                .orElseThrow(() -> new ReservationNotFoundException(id.toString()));
+        reservation.setStatus("CANCELLED");
+        Reservation updated = repository.save(reservation);
+        ReservationDto result = mapper.toReservationDto(updated);
+        notificationService.send("Reservation cancelled " + updated.getId());
+        return result;
+    }
+}

--- a/src/main/java/com/playtodoo/modulith/reservations/exception/ReservationNotFoundException.java
+++ b/src/main/java/com/playtodoo/modulith/reservations/exception/ReservationNotFoundException.java
@@ -1,0 +1,7 @@
+package com.playtodoo.modulith.reservations.exception;
+
+public class ReservationNotFoundException extends RuntimeException {
+    public ReservationNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/playtodoo/modulith/reservations/infrastructure/ReservationRepository.java
+++ b/src/main/java/com/playtodoo/modulith/reservations/infrastructure/ReservationRepository.java
@@ -1,0 +1,11 @@
+package com.playtodoo.modulith.reservations.infrastructure;
+
+import com.playtodoo.modulith.reservations.domain.Reservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface ReservationRepository extends JpaRepository<Reservation, UUID> {
+}

--- a/src/main/java/com/playtodoo/modulith/reservations/mapper/ReservationMapper.java
+++ b/src/main/java/com/playtodoo/modulith/reservations/mapper/ReservationMapper.java
@@ -1,0 +1,12 @@
+package com.playtodoo.modulith.reservations.mapper;
+
+import com.playtodoo.modulith.reservations.domain.Reservation;
+import com.playtodoo.modulith.reservations.validation.CreateReservationDto;
+import com.playtodoo.modulith.reservations.validation.ReservationDto;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface ReservationMapper {
+    Reservation toReservation(CreateReservationDto dto);
+    ReservationDto toReservationDto(Reservation reservation);
+}

--- a/src/main/java/com/playtodoo/modulith/reservations/presentation/ReservationController.java
+++ b/src/main/java/com/playtodoo/modulith/reservations/presentation/ReservationController.java
@@ -1,0 +1,34 @@
+package com.playtodoo.modulith.reservations.presentation;
+
+import com.playtodoo.modulith.reservations.application.ReservationService;
+import com.playtodoo.modulith.reservations.validation.CreateReservationDto;
+import com.playtodoo.modulith.reservations.validation.ReservationDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/reservations")
+@RequiredArgsConstructor
+public class ReservationController {
+
+    private final ReservationService service;
+
+    @PostMapping
+    public ResponseEntity<ReservationDto> create(@Valid @RequestBody CreateReservationDto dto) {
+        return ResponseEntity.ok(service.create(dto));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ReservationDto> update(@PathVariable UUID id, @Valid @RequestBody CreateReservationDto dto) {
+        return ResponseEntity.ok(service.update(id, dto));
+    }
+
+    @PatchMapping("/{id}/cancel")
+    public ResponseEntity<ReservationDto> cancel(@PathVariable UUID id) {
+        return ResponseEntity.ok(service.cancel(id));
+    }
+}

--- a/src/main/java/com/playtodoo/modulith/reservations/validation/CreateReservationDto.java
+++ b/src/main/java/com/playtodoo/modulith/reservations/validation/CreateReservationDto.java
@@ -1,0 +1,14 @@
+package com.playtodoo.modulith.reservations.validation;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record CreateReservationDto(
+        @NotNull UUID courtId,
+        @NotNull UUID userId,
+        @NotNull LocalDateTime startTime,
+        @NotNull LocalDateTime endTime,
+        String status
+) {}

--- a/src/main/java/com/playtodoo/modulith/reservations/validation/ReservationDto.java
+++ b/src/main/java/com/playtodoo/modulith/reservations/validation/ReservationDto.java
@@ -1,0 +1,17 @@
+package com.playtodoo.modulith.reservations.validation;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Builder
+public record ReservationDto(
+        UUID id,
+        UUID courtId,
+        UUID userId,
+        LocalDateTime startTime,
+        LocalDateTime endTime,
+        String status,
+        LocalDateTime createdAt
+) {}

--- a/src/test/java/com/playtodoo/modulith/reservations/ReservationServiceImplTest.java
+++ b/src/test/java/com/playtodoo/modulith/reservations/ReservationServiceImplTest.java
@@ -1,0 +1,94 @@
+package com.playtodoo.modulith.reservations;
+
+import com.playtodoo.modulith.notifications.NotificationService;
+import com.playtodoo.modulith.reservations.application.impl.ReservationServiceImpl;
+import com.playtodoo.modulith.reservations.domain.Reservation;
+import com.playtodoo.modulith.reservations.exception.ReservationNotFoundException;
+import com.playtodoo.modulith.reservations.infrastructure.ReservationRepository;
+import com.playtodoo.modulith.reservations.mapper.ReservationMapper;
+import com.playtodoo.modulith.reservations.validation.CreateReservationDto;
+import com.playtodoo.modulith.reservations.validation.ReservationDto;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+class ReservationServiceImplTest {
+
+    @Mock
+    private ReservationRepository repository;
+    @Mock
+    private ReservationMapper mapper;
+    @Mock
+    private NotificationService notificationService;
+    @InjectMocks
+    private ReservationServiceImpl service;
+
+    @Test
+    void shouldCreateReservation() {
+        CreateReservationDto dto = new CreateReservationDto(UUID.randomUUID(), UUID.randomUUID(), LocalDateTime.now(), LocalDateTime.now().plusHours(1), "PENDING");
+        Reservation reservation = new Reservation();
+        when(mapper.toReservation(dto)).thenReturn(reservation);
+        when(repository.save(reservation)).thenReturn(reservation);
+        ReservationDto expected = ReservationDto.builder().id(UUID.randomUUID()).build();
+        when(mapper.toReservationDto(reservation)).thenReturn(expected);
+
+        ReservationDto result = service.create(dto);
+
+        assertThat(result).isEqualTo(expected);
+        verify(notificationService).send(startsWith("Reservation created"));
+    }
+
+    @Test
+    void shouldUpdateReservation() {
+        UUID id = UUID.randomUUID();
+        CreateReservationDto dto = new CreateReservationDto(UUID.randomUUID(), UUID.randomUUID(), LocalDateTime.now(), LocalDateTime.now().plusHours(1), "CONFIRMED");
+        Reservation reservation = new Reservation();
+        when(repository.findById(id)).thenReturn(Optional.of(reservation));
+        when(repository.save(reservation)).thenReturn(reservation);
+        ReservationDto expected = ReservationDto.builder().id(id).build();
+        when(mapper.toReservationDto(reservation)).thenReturn(expected);
+
+        ReservationDto result = service.update(id, dto);
+
+        assertThat(result).isEqualTo(expected);
+        verify(notificationService).send(startsWith("Reservation updated"));
+    }
+
+    @Test
+    void shouldThrowWhenReservationNotFound() {
+        UUID id = UUID.randomUUID();
+        CreateReservationDto dto = new CreateReservationDto(UUID.randomUUID(), UUID.randomUUID(), LocalDateTime.now(), LocalDateTime.now().plusHours(1), "CONFIRMED");
+        when(repository.findById(id)).thenReturn(Optional.empty());
+
+        assertThrows(ReservationNotFoundException.class, () -> service.update(id, dto));
+    }
+
+    @Test
+    void shouldCancelReservation() {
+        UUID id = UUID.randomUUID();
+        Reservation reservation = new Reservation();
+        when(repository.findById(id)).thenReturn(Optional.of(reservation));
+        when(repository.save(reservation)).thenReturn(reservation);
+        ReservationDto expected = ReservationDto.builder().id(id).build();
+        when(mapper.toReservationDto(reservation)).thenReturn(expected);
+
+        ReservationDto result = service.cancel(id);
+
+        assertThat(result).isEqualTo(expected);
+        verify(notificationService).send(startsWith("Reservation cancelled"));
+    }
+}


### PR DESCRIPTION
## Summary
- add `WebSocketConfig` for STOMP endpoints
- create `NotificationService` to publish to `/topic/notifications`
- implement Reservation service, repository, mapper and controller
- add DTOs and exception for reservations
- tests for reservation service

## Testing
- `mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685c14b83af8832b9bdcbc4fe4e75f6e