### PR TITLE
Implement License CRUD module

### DIFF
--- a/src/main/java/com/playtodoo/modulith/licensing/application/LicenseService.java
+++ b/src/main/java/com/playtodoo/modulith/licensing/application/LicenseService.java
@@ -1,0 +1,15 @@
+package com.playtodoo.modulith.licensing.application;
+
+import com.playtodoo.modulith.common.PageResponse;
+import com.playtodoo.modulith.licensing.validation.CreateLicenseDto;
+import com.playtodoo.modulith.licensing.validation.LicenseDto;
+
+import java.util.UUID;
+
+public interface LicenseService {
+    LicenseDto create(CreateLicenseDto dto);
+    PageResponse<LicenseDto> findAll(int page, int size, String sortField, String sortDirection);
+    LicenseDto findById(UUID id);
+    LicenseDto update(UUID id, CreateLicenseDto dto);
+    void delete(UUID id);
+}

--- a/src/main/java/com/playtodoo/modulith/licensing/application/impl/LicenseServiceImpl.java
+++ b/src/main/java/com/playtodoo/modulith/licensing/application/impl/LicenseServiceImpl.java
@@ -1,0 +1,74 @@
+package com.playtodoo.modulith.licensing.application.impl;
+
+import com.playtodoo.modulith.common.PageResponse;
+import com.playtodoo.modulith.licensing.application.LicenseService;
+import com.playtodoo.modulith.licensing.domain.License;
+import com.playtodoo.modulith.licensing.domain.Plan;
+import com.playtodoo.modulith.licensing.exception.LicenseNotFoundException;
+import com.playtodoo.modulith.licensing.exception.PlanNotFoundException;
+import com.playtodoo.modulith.licensing.infrastructure.LicenseRepository;
+import com.playtodoo.modulith.licensing.infrastructure.PlanRepository;
+import com.playtodoo.modulith.licensing.mapper.LicenseMapper;
+import com.playtodoo.modulith.licensing.validation.CreateLicenseDto;
+import com.playtodoo.modulith.licensing.validation.LicenseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class LicenseServiceImpl implements LicenseService {
+
+    private final LicenseRepository repository;
+    private final PlanRepository planRepository;
+    private final LicenseMapper mapper;
+
+    @Override
+    public LicenseDto create(CreateLicenseDto dto) {
+        License license = mapper.toLicense(dto);
+        Plan plan = planRepository.findByType(dto.planType())
+                .orElseThrow(() -> new PlanNotFoundException(dto.planType()));
+        license.setPlan(plan);
+        License saved = repository.save(license);
+        return mapper.toLicenseDto(saved);
+    }
+
+    @Override
+    public PageResponse<LicenseDto> findAll(int page, int size, String sortField, String sortDirection) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.fromString(sortDirection), sortField));
+        Page<License> pageResult = repository.findAll(pageable);
+        List<LicenseDto> dtos = pageResult.getContent().stream().map(mapper::toLicenseDto).toList();
+        return PageResponse.fromPage(new PageImpl<>(dtos, pageable, pageResult.getTotalElements()), sortField, sortDirection);
+    }
+
+    @Override
+    public LicenseDto findById(UUID id) {
+        License license = repository.findById(id).orElseThrow(() -> new LicenseNotFoundException(id.toString()));
+        return mapper.toLicenseDto(license);
+    }
+
+    @Override
+    public LicenseDto update(UUID id, CreateLicenseDto dto) {
+        License license = repository.findById(id).orElseThrow(() -> new LicenseNotFoundException(id.toString()));
+        Plan plan = planRepository.findByType(dto.planType())
+                .orElseThrow(() -> new PlanNotFoundException(dto.planType()));
+        license.setSportComplexId(dto.sportComplexId());
+        license.setPlan(plan);
+        license.setExpirationDate(dto.expirationDate());
+        license.setStatus(dto.status());
+        License updated = repository.save(license);
+        return mapper.toLicenseDto(updated);
+    }
+
+    @Override
+    public void delete(UUID id) {
+        License license = repository.findById(id).orElseThrow(() -> new LicenseNotFoundException(id.toString()));
+        license.setStatus("INA");
+        repository.save(license);
+    }
+}

--- a/src/main/java/com/playtodoo/modulith/licensing/exception/LicenseNotFoundException.java
+++ b/src/main/java/com/playtodoo/modulith/licensing/exception/LicenseNotFoundException.java
@@ -1,0 +1,7 @@
+package com.playtodoo.modulith.licensing.exception;
+
+public class LicenseNotFoundException extends RuntimeException {
+    public LicenseNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/playtodoo/modulith/licensing/infrastructure/LicenseRepository.java
+++ b/src/main/java/com/playtodoo/modulith/licensing/infrastructure/LicenseRepository.java
@@ -1,12 +1,11 @@
 package com.playtodoo.modulith.licensing.infrastructure;
 
-import com.playtodoo.modulith.licensing.domain.Plan;
+import com.playtodoo.modulith.licensing.domain.License;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.UUID;
 
 @Repository
-public interface PlanRepository extends JpaRepository<Plan, UUID> {
-    java.util.Optional<Plan> findByType(String type);
+public interface LicenseRepository extends JpaRepository<License, UUID> {
 }

--- a/src/main/java/com/playtodoo/modulith/licensing/mapper/LicenseMapper.java
+++ b/src/main/java/com/playtodoo/modulith/licensing/mapper/LicenseMapper.java
@@ -1,0 +1,16 @@
+package com.playtodoo.modulith.licensing.mapper;
+
+import com.playtodoo.modulith.licensing.domain.License;
+import com.playtodoo.modulith.licensing.validation.CreateLicenseDto;
+import com.playtodoo.modulith.licensing.validation.LicenseDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface LicenseMapper {
+    @Mapping(target = "plan", ignore = true)
+    License toLicense(CreateLicenseDto dto);
+
+    @Mapping(source = "plan.type", target = "planType")
+    LicenseDto toLicenseDto(License license);
+}

--- a/src/main/java/com/playtodoo/modulith/licensing/presentation/LicenseController.java
+++ b/src/main/java/com/playtodoo/modulith/licensing/presentation/LicenseController.java
@@ -1,0 +1,50 @@
+package com.playtodoo.modulith.licensing.presentation;
+
+import com.playtodoo.modulith.common.PageResponse;
+import com.playtodoo.modulith.licensing.application.LicenseService;
+import com.playtodoo.modulith.licensing.validation.CreateLicenseDto;
+import com.playtodoo.modulith.licensing.validation.LicenseDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/licensing/licenses")
+@RequiredArgsConstructor
+public class LicenseController {
+
+    private final LicenseService service;
+
+    @PostMapping
+    public ResponseEntity<LicenseDto> create(@Valid @RequestBody CreateLicenseDto dto) {
+        return ResponseEntity.ok(service.create(dto));
+    }
+
+    @GetMapping
+    public ResponseEntity<PageResponse<LicenseDto>> getAll(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "expirationDate") String sortField,
+            @RequestParam(defaultValue = "asc") String direction) {
+        return ResponseEntity.ok(service.findAll(page, size, sortField, direction));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<LicenseDto> getById(@PathVariable UUID id) {
+        return ResponseEntity.ok(service.findById(id));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<LicenseDto> update(@PathVariable UUID id, @Valid @RequestBody CreateLicenseDto dto) {
+        return ResponseEntity.ok(service.update(id, dto));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable UUID id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/playtodoo/modulith/licensing/validation/CreateLicenseDto.java
+++ b/src/main/java/com/playtodoo/modulith/licensing/validation/CreateLicenseDto.java
@@ -1,0 +1,14 @@
+package com.playtodoo.modulith.licensing.validation;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record CreateLicenseDto(
+        @NotNull UUID sportComplexId,
+        @NotBlank String planType,
+        @NotNull LocalDateTime expirationDate,
+        @NotBlank String status
+) {}

--- a/src/main/java/com/playtodoo/modulith/licensing/validation/LicenseDto.java
+++ b/src/main/java/com/playtodoo/modulith/licensing/validation/LicenseDto.java
@@ -1,0 +1,12 @@
+package com.playtodoo.modulith.licensing.validation;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record LicenseDto(
+        UUID id,
+        UUID sportComplexId,
+        String planType,
+        LocalDateTime expirationDate,
+        String status
+) {}


### PR DESCRIPTION
## Summary
- add repository method to find Plan by type
- implement license repository
- implement DTOs and mapper for License
- implement License service and controller with CRUD operations
- create LicenseNotFoundException

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_685cb2ccb94c832b899f02024a1caff2